### PR TITLE
Correções EOL Centos 8

### DIFF
--- a/provisionamento/logging.sh
+++ b/provisionamento/logging.sh
@@ -29,6 +29,8 @@ else
   echo "[OK] SSH KEY"
 fi
 
+# Solução temporaria para EOL Centos 8 - S. Goncalves
+sudo rpm -Uhv --nodeps http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-release-8.5-3.el8.noarch.rpm >/dev/null 2>>/var/log/vagrant_provision.log
 # Instalando Pacotes
 sudo dnf install -q -y ${DEPS_PACKAGES} ${PACKAGES} >/dev/null 2>>/var/log/vagrant_provision.log
 

--- a/provisionamento/logging.sh
+++ b/provisionamento/logging.sh
@@ -29,7 +29,7 @@ else
   echo "[OK] SSH KEY"
 fi
 
-# Solução temporaria para EOL Centos 8 - S. Goncalves
+# Solução temporaria para EOL Centos 8 - by S. Goncalves
 sudo rpm -Uhv --nodeps http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-release-8.5-3.el8.noarch.rpm >/dev/null 2>>/var/log/vagrant_provision.log
 # Instalando Pacotes
 sudo dnf install -q -y ${DEPS_PACKAGES} ${PACKAGES} >/dev/null 2>>/var/log/vagrant_provision.log

--- a/provisionamento/logging.sh
+++ b/provisionamento/logging.sh
@@ -29,8 +29,9 @@ else
   echo "[OK] SSH KEY"
 fi
 
-# Solução temporaria para EOL Centos 8 - by S. Goncalves
+# Solução temporaria para EOL Centos 8
 sudo rpm -Uhv --nodeps http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-release-8.5-3.el8.noarch.rpm >/dev/null 2>>/var/log/vagrant_provision.log
+
 # Instalando Pacotes
 sudo dnf install -q -y ${DEPS_PACKAGES} ${PACKAGES} >/dev/null 2>>/var/log/vagrant_provision.log
 

--- a/provisionamento/testing.sh
+++ b/provisionamento/testing.sh
@@ -31,8 +31,9 @@ else
   echo "[OK] SSH KEY"
 fi
 
-# Solução temporaria para EOL Centos 8 - S. Goncalves
+# Solução temporaria para EOL Centos 8
 sudo rpm -Uhv --nodeps http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-release-8.5-3.el8.noarch.rpm >/dev/null 2>>/var/log/vagrant_provision.log
+
 # Instalando Pacotes
 sudo dnf install -q -y ${DEPS_PACKAGES} ${PACKAGES} ${GUI_PACKAGES} >/dev/null 2>>/var/log/vagrant_provision.log
 

--- a/provisionamento/testing.sh
+++ b/provisionamento/testing.sh
@@ -31,6 +31,8 @@ else
   echo "[OK] SSH KEY"
 fi
 
+# Solução temporaria para EOL Centos 8 - S. Goncalves
+sudo rpm -Uhv --nodeps http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-release-8.5-3.el8.noarch.rpm >/dev/null 2>>/var/log/vagrant_provision.log
 # Instalando Pacotes
 sudo dnf install -q -y ${DEPS_PACKAGES} ${PACKAGES} ${GUI_PACKAGES} >/dev/null 2>>/var/log/vagrant_provision.log
 


### PR DESCRIPTION
## Descrição das alterações

É realizada a instalação dos repositórios `BaseOS` e `centos-stream` por meio do comando:
```bash
sudo rpm -Uhv --nodeps http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-release-8.5-3.el8.noarch.rpm >/dev/null 2>>/var/log/vagrant_provision.log
```

